### PR TITLE
QR作成-step2 音声データの設定のスタイル

### DIFF
--- a/src/app/ar_assets/create/_components/CreateArAssetStepper.tsx
+++ b/src/app/ar_assets/create/_components/CreateArAssetStepper.tsx
@@ -9,9 +9,11 @@ import {
 } from './StepContent';
 import { Button } from '@/shared/components/common/Button';
 import { Container } from '@/shared/components/common/Container';
-import { Group } from '@/shared/components/common/Layout';
+import { Group, Space } from '@/shared/components/common/Layout';
 import { Anchor } from '@/shared/components/common/Navigation';
 import { Stepper } from '@/shared/components/common/Stepper';
+import { IconChevronLeft } from '@/shared/components/icons/IconChevronLeft';
+import { IconChevronRight } from '@/shared/components/icons/IconChevronRight';
 
 export const CreateArAssetStepper = () => {
   const [active, setActive] = useState(0);
@@ -71,31 +73,43 @@ export const CreateArAssetStepper = () => {
           <CompletedArAsset />
         </Stepper.Completed>
       </Stepper>
-      <Group justify="center">
-        {active == 3 ? (
-          <Anchor component={Link} href="/ar_assets">
-            QRコード一覧へ
-          </Anchor>
-        ) : (
-          <Group justify="center" mt="xl">
-            {active !== 0 && (
-              <Button
-                variant="default"
-                onClick={() => handleStepChange(active - 1)}
-              >
-                前のステップに戻る
-              </Button>
-            )}
-            {active !== 2 ? (
-              <Button onClick={() => handleStepChange(active + 1)}>
-                次のステップへ
-              </Button>
-            ) : (
-              <Button onClick={() => handleStepChange(active + 1)}>完了</Button>
-            )}
-          </Group>
-        )}
-      </Group>
+
+      {active == 3 ? (
+        <Anchor component={Link} href="/ar_assets">
+          QRコード一覧へ
+        </Anchor>
+      ) : (
+        <Group
+          my="xl"
+          p={0}
+          justify={active !== 0 ? 'space-between' : 'flex-end'}
+        >
+          {active !== 0 && (
+            <Button
+              variant="outline"
+              size="xs"
+              leftSection={<IconChevronLeft size={14} />}
+              onClick={() => handleStepChange(active - 1)}
+            >
+              前のステップ
+            </Button>
+          )}
+          {active !== 2 ? (
+            <Button
+              size="xs"
+              rightSection={<IconChevronRight size={14} />}
+              onClick={() => handleStepChange(active + 1)}
+            >
+              次のステップへ
+            </Button>
+          ) : (
+            <Button size="xs" onClick={() => handleStepChange(active + 1)}>
+              完了
+            </Button>
+          )}
+        </Group>
+      )}
+      <Space h="md" />
     </Container>
   );
 };

--- a/src/app/ar_assets/create/_components/StepContent/SpeakingSettings.tsx
+++ b/src/app/ar_assets/create/_components/StepContent/SpeakingSettings.tsx
@@ -1,3 +1,20 @@
+import {
+  RecordedModelSettings,
+  SpeakingAssetsSettings,
+} from './SpeakingSettingsContent';
+import { Container } from '@/shared/components/common/Container';
+import { Divider } from '@/shared/components/common/Divider';
+import { Title } from '@/shared/components/common/Title';
+
 export const SpeakingSettings = () => {
-  return <>音声データの設定</>;
+  return (
+    <Container>
+      <Title order={3} c="blue.6" mb={16}>
+        音声データの設定
+      </Title>
+      <RecordedModelSettings />
+      <Divider my="sm" />
+      <SpeakingAssetsSettings />
+    </Container>
+  );
 };

--- a/src/app/ar_assets/create/_components/StepContent/SpeakingSettingsContent/RecordedModelSettings.tsx
+++ b/src/app/ar_assets/create/_components/StepContent/SpeakingSettingsContent/RecordedModelSettings.tsx
@@ -1,0 +1,44 @@
+import { ActionIcon } from '@mantine/core';
+import { IconMicrophone } from '@tabler/icons-react';
+import { Button } from '@/shared/components/common/Button';
+import { Container } from '@/shared/components/common/Container';
+import { Stack } from '@/shared/components/common/Layout';
+import { Text } from '@/shared/components/common/Text';
+import { Title } from '@/shared/components/common/Title';
+
+export const RecordedModelSettings = () => {
+  return (
+    <Container p={0}>
+      <Title order={5} c="blue.6" mb={4}>
+        生成元音声の設定
+      </Title>
+      <Text size="xs" c="gray.6" mb={12}>
+        生成される音声はこの録音データを元に生成されます録音データ(生成元音声)は1つのアカウントで1つだけです。
+      </Text>
+      <Stack align="center" gap="xs" my="lg">
+        <ActionIcon
+          variant="filled"
+          color="orange"
+          size="xl"
+          radius="xl"
+          aria-label="Settings"
+        >
+          <IconMicrophone
+            style={{ width: '70%', height: '70%' }}
+            stroke={1.5}
+          />
+        </ActionIcon>
+        <Button variant="transparent" color="orange" size="compact-xs">
+          タップして録音
+        </Button>
+      </Stack>
+      <Title order={6} c="blue.6" mb={4}>
+        録音音声
+      </Title>
+      <Text size="xs" c="gray.6" mb={12}>
+        生成される音声はこの録音データを元に生成されます
+      </Text>
+      <audio controls src=""></audio>
+    </Container>
+  );
+};

--- a/src/app/ar_assets/create/_components/StepContent/SpeakingSettingsContent/SpeakingAssetsSettings.tsx
+++ b/src/app/ar_assets/create/_components/StepContent/SpeakingSettingsContent/SpeakingAssetsSettings.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@/shared/components/common/Button';
+import { Container } from '@/shared/components/common/Container';
+import { Textarea } from '@/shared/components/common/Input';
+import { Stack } from '@/shared/components/common/Layout';
+import { Text } from '@/shared/components/common/Text';
+import { Title } from '@/shared/components/common/Title';
+
+export const SpeakingAssetsSettings = () => {
+  return (
+    <Container p={0}>
+      <Title order={5} c="blue.6" mb={4}>
+        合成音声の設定
+      </Title>
+      <Text size="xs" c="gray.6" mb={12}>
+        QRコードを読み込むと再生できる音声です。
+      </Text>
+      <Title order={6} c="blue.6" mb={4}>
+        合成音声
+      </Title>
+      <Text size="xs" c="gray.6" mb={12}>
+        生成されるまでに5分ほどかかる場合があります
+      </Text>
+      <audio controls src=""></audio>
+      <Title order={6} c="blue.6" my={4}>
+        話させる文章
+      </Title>
+      <Text size="xs" c="gray.6" mb={12}>
+        登録した声がAI化されて再生される文章です
+      </Text>
+      <Stack align="flex-start" justify="flex-start" mb={12} gap="xs">
+        <Textarea
+          placeholder="100文字以下で入力してください。"
+          autosize
+          minRows={3}
+          mb={8}
+          w={'100%'}
+        />
+        <Button variant="outline" color="orange" size="xs" radius="xl">
+          保存して合成音声を生成する
+        </Button>
+      </Stack>
+    </Container>
+  );
+};

--- a/src/app/ar_assets/create/_components/StepContent/SpeakingSettingsContent/index.ts
+++ b/src/app/ar_assets/create/_components/StepContent/SpeakingSettingsContent/index.ts
@@ -1,0 +1,2 @@
+export { RecordedModelSettings } from './RecordedModelSettings';
+export { SpeakingAssetsSettings } from './SpeakingAssetsSettings';

--- a/src/shared/components/common/Input/Textarea.tsx
+++ b/src/shared/components/common/Input/Textarea.tsx
@@ -1,0 +1,3 @@
+import { Textarea as MantineTextarea } from '@mantine/core';
+
+export const Textarea = MantineTextarea;

--- a/src/shared/components/common/Input/index.ts
+++ b/src/shared/components/common/Input/index.ts
@@ -2,3 +2,4 @@ export { PasswordInput } from './PasswordInput';
 export { TextInput } from './TextInput';
 export { Radio } from './Radio';
 export { FileInput } from './FileInput';
+export { Textarea } from './Textarea';

--- a/src/shared/components/icons/IconChevronLeft.tsx
+++ b/src/shared/components/icons/IconChevronLeft.tsx
@@ -1,0 +1,3 @@
+import { IconChevronLeft as TablerChevronLeft } from '@tabler/icons-react';
+
+export const IconChevronLeft = TablerChevronLeft;

--- a/src/shared/components/icons/IconChevronRight.tsx
+++ b/src/shared/components/icons/IconChevronRight.tsx
@@ -1,0 +1,3 @@
+import { IconChevronRight as TablerChevronRight } from '@tabler/icons-react';
+
+export const IconChevronRight = TablerChevronRight;


### PR DESCRIPTION

### 関連issue

- close #63 

### 説明
`http://localhost:3000/ar_assets/create`QR作成-step2のスタイルの実装しました。

Figmaデザイン
https://www.figma.com/file/IvK6mJQejA6U9I5bnTRPf2/%E3%83%AF%E3%82%A4%E3%83%A4%E3%83%BC%E3%83%95%E3%83%AC%E3%83%BC%E3%83%A0?type=design&node-id=325%3A949&mode=design&t=ZqP6kS9lqCTT85ip-1

### 実装画面
<img width="239" alt="スクリーンショット 2023-12-02 17 03 09" src="https://github.com/Misoten-B/airship-frontend/assets/80940288/bb93ac43-8b7c-499e-a110-4d938ff03276">
<!-- 関連issueがある場合は省略してください -->

### その他
機能の実装はしてません。

<!-- 追記事項。そのほかお見送り事項 -->
