### PR TITLE
QRコード一覧UI

### DIFF
--- a/src/app/ar_assets/_components/ArAssetCard.tsx
+++ b/src/app/ar_assets/_components/ArAssetCard.tsx
@@ -1,0 +1,31 @@
+import { Image } from '@/shared/components/common/Image';
+import { Card, Flex } from '@/shared/components/common/Layout';
+import { QRCode } from '@/shared/components/common/QRCode';
+import { Text } from '@/shared/components/common/Text';
+import { Title } from '@/shared/components/common/Title';
+
+export const ArAssetCard = () => {
+  return (
+    <Card radius="md" withBorder mx={16} padding={0} p={20} my={8}>
+      <Card.Section mb={16}>
+        <Flex gap={16} justify="center">
+          <QRCode
+            url="https://airship.com"
+            imageSrc="/airship-logo-column.svg"
+            size={100}
+          />
+          <Image src="/3d_model_image.svg" alt="#" />
+        </Flex>
+      </Card.Section>
+      <Flex direction="column" align="flex-start">
+        <audio controls src="" style={{ width: '100%', height: '30px' }} />
+        <Title order={6} c="blue.6" mt={16} mb={4}>
+          話させる文章
+        </Title>
+        <Text size="xs" lineClamp={2}>
+          私の名前は奥田晶貴です。好きなことはゲームをすることとカラオケで歌を歌うことです。長所は笑顔で接するこ
+        </Text>
+      </Flex>
+    </Card>
+  );
+};

--- a/src/app/ar_assets/_components/ArAssetList.tsx
+++ b/src/app/ar_assets/_components/ArAssetList.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { ArAssetCard } from './ArAssetCard';
+import { Button } from '@/shared/components/common/Button';
+import { Container } from '@/shared/components/common/Container';
+import { Flex, Grid, Stack } from '@/shared/components/common/Layout';
+import { Text } from '@/shared/components/common/Text';
+
+export const ArAssetList = () => {
+  return (
+    <Container bg="blue.1" p={0}>
+      <Flex gap={8} justify="center" px={24} py={12} bg="white" mb={16}>
+        <Stack gap={0}>
+          <Text size="xs" c="orange" ta="center" mb={4}>
+            3Dモデルと話させる文章を登録して QRコード化させます
+          </Text>
+          <Button variant="filled" color="orange" size="md" radius="xl">
+            <Text>QRコードの新規作成</Text>
+          </Button>
+        </Stack>
+        <Stack gap={0}>
+          <Text size="xs" c="blue" ta="center" mb={4}>
+            5秒ほど自分の声を登録すると 自分の声がAI化されます
+          </Text>
+          <Button variant="filled" size="md" radius="xl" w={160}>
+            <Text>声を登録する</Text>
+          </Button>
+        </Stack>
+      </Flex>
+      <Grid px={16}>
+        <ArAssetCard />
+        <ArAssetCard />
+        <ArAssetCard />
+        <ArAssetCard />
+      </Grid>
+    </Container>
+  );
+};

--- a/src/app/ar_assets/create/_components/StepContent/Select3dModel.tsx
+++ b/src/app/ar_assets/create/_components/StepContent/Select3dModel.tsx
@@ -46,7 +46,7 @@ export const Select3dModel = ({}: Props) => {
           return (
             <Grid.Col key={id} span={4}>
               <Stack gap="sm" align="center">
-                <Image src={imageSrc} alt={`${id} 3d model`} />
+                <Image src={'/' + imageSrc} alt={`${id} 3d model`} />
                 {/* TODO: wip */}
                 <Radio name="" control={control} size="xs" />
               </Stack>
@@ -67,7 +67,7 @@ export const Select3dModel = ({}: Props) => {
           return (
             <Grid.Col key={id} span={4}>
               <Stack gap="sm" align="center">
-                <Image src={imageSrc} alt={`${id} 3d model`} />
+                <Image src={'/' + imageSrc} alt={`${id} 3d model`} />
                 {/* TODO: wip */}
                 <Radio name="" control={control} size="xs" />
               </Stack>

--- a/src/app/ar_assets/create/_components/StepContent/UploadQRCodeInsideImage.tsx
+++ b/src/app/ar_assets/create/_components/StepContent/UploadQRCodeInsideImage.tsx
@@ -4,7 +4,7 @@ import { Container } from '@/shared/components/common/Container';
 import { Center, Group, Stack } from '@/shared/components/common/Layout';
 import { Text } from '@/shared/components/common/Text';
 import { Title } from '@/shared/components/common/Title';
-import { SampleQrCodeImage } from '@/shared/components/features/QRCodeImage';
+import { SampleQrCodeImage } from '@/shared/components/features';
 import { IconUpload } from '@/shared/components/icons/IconUpload';
 
 export const UploadQRCodeInsideImage = () => {

--- a/src/app/ar_assets/page.tsx
+++ b/src/app/ar_assets/page.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from 'next';
-import { Guard } from '@/shared/components/features';
+import { ArAssetList } from './_components/ArAssetList';
 
 const Page: NextPage = () => {
-  return <Guard>ar_asset</Guard>;
+  return <ArAssetList />;
 };
 
 export default Page;

--- a/src/shared/components/features/index.ts
+++ b/src/shared/components/features/index.ts
@@ -1,2 +1,3 @@
 export { Guard } from './Guard';
 export { LoginButton } from './LoginButton';
+export { SampleQrCodeImage } from './QRCodeImage';


### PR DESCRIPTION
### 関連issue

- close #68 

### 説明
QRコード一覧の画面を作成しました
<img width="288" alt="スクリーンショット 2023-12-04 0 52 10" src="https://github.com/Misoten-B/airship-frontend/assets/85974240/61abb35f-a518-4380-bf5c-57c8f8d9310c">


<!-- 関連issueがある場合は省略してください -->

### その他
#### やってないこと

- QR作成Buttonを押したら作成画面へ飛ぶように
<img width="155" alt="スクリーンショット 2023-12-04 0 50 02" src="https://github.com/Misoten-B/airship-frontend/assets/85974240/50cf20b4-1149-428f-8954-19ba0f1fcaf4">

- カードを押したら詳細画面へ飛ぶ
<img width="528" alt="スクリーンショット 2023-12-04 0 49 21" src="https://github.com/Misoten-B/airship-frontend/assets/85974240/d9fcd581-e042-407d-8efa-d509ab7c6e44">


<!-- 追記事項。そのほかお見送り事項 -->
