### PR TITLE
fix: firebase auth idToken

### DIFF
--- a/src/shared/lib/firebase/firebase.ts
+++ b/src/shared/lib/firebase/firebase.ts
@@ -42,7 +42,11 @@ export const firebaseSignInWithGoogle = async () => {
   try {
     const result = await signInWithPopup(auth, provider);
     const credential = GoogleAuthProvider.credentialFromResult(result);
-    const token = credential!.accessToken;
+    const token = auth.currentUser?.getIdToken().then((token) => {
+      console.debug('token', token);
+      return token;
+    });
+    console.debug('token', token);
     return { token: token, user: result.user };
   } catch (error) {
     throw error;


### PR DESCRIPTION
### 関連issue

- close #81 

### 説明

- `getIdToken()`を使わないとバック側のSDKで認証が通らない
https://stackoverflow.com/questions/38335127/firebase-auth-id-token-has-incorrect-aud-claim

<!-- 関連issueがある場合は省略してください -->

### その他

コードについてはバックで使いたくて書いただけなので、修正求
@hkiku482 

<!-- 追記事項。そのほかお見送り事項 -->
