### PR TITLE
add:mantine Modal作成

### DIFF
--- a/src/app/ar-assets/[ar_asset_id]/_components/ArAssetDetailContent/Display3dModel.tsx
+++ b/src/app/ar-assets/[ar_asset_id]/_components/ArAssetDetailContent/Display3dModel.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { useDisclosure } from '@mantine/hooks';
 import { Button } from '@/shared/components/common/Button';
 import { Container } from '@/shared/components/common/Container';
 import { Divider } from '@/shared/components/common/Divider';
@@ -10,27 +9,30 @@ import { Modal } from '@/shared/components/common/Modal';
 import { Radio } from '@/shared/components/common/Radio';
 import { Text } from '@/shared/components/common/Text';
 import { Title } from '@/shared/components/common/Title';
+import { useDisclosure } from '@/shared/hooks/useDisclosure';
 import { useForm } from '@/shared/hooks/useForm';
+
+const mock3dModels: { id: number; imageSrc: string }[] = [
+  {
+    id: 1,
+    imageSrc: '/3d_model_image.svg',
+  },
+  {
+    id: 2,
+    imageSrc: '/3d_model_image.svg',
+  },
+  {
+    id: 3,
+    imageSrc: '/3d_model_image.svg',
+  },
+];
 
 export const Display3dModel = () => {
   const [opened, { open, close }] = useDisclosure(false);
-  const mock3dModels: { id: number; imageSrc: string }[] = [
-    {
-      id: 1,
-      imageSrc: '/3d_model_image.svg',
-    },
-    {
-      id: 2,
-      imageSrc: '/3d_model_image.svg',
-    },
-    {
-      id: 3,
-      imageSrc: '/3d_model_image.svg',
-    },
-  ];
   const { control } = useForm();
   const sampleModels = mock3dModels;
   const uploadedModels = mock3dModels;
+
   return (
     <Stack gap={0}>
       <Title order={5} c="blue.6" mb={4}>
@@ -84,6 +86,7 @@ export const Display3dModel = () => {
                   </Grid.Col>
                 );
               })}
+
               <Grid.Col span={4}>
                 <FileInput
                   // TODO: wip

--- a/src/app/ar-assets/[ar_asset_id]/_components/ArAssetDetailContent/Display3dModel.tsx
+++ b/src/app/ar-assets/[ar_asset_id]/_components/ArAssetDetailContent/Display3dModel.tsx
@@ -1,10 +1,36 @@
+'use client';
+import { useDisclosure } from '@mantine/hooks';
 import { Button } from '@/shared/components/common/Button';
+import { Container } from '@/shared/components/common/Container';
+import { Divider } from '@/shared/components/common/Divider';
 import { Image } from '@/shared/components/common/Image';
-import { Group, Stack } from '@/shared/components/common/Layout';
+import { FileInput } from '@/shared/components/common/Input';
+import { Grid, Group, Stack } from '@/shared/components/common/Layout';
+import { Modal } from '@/shared/components/common/Modal';
+import { Radio } from '@/shared/components/common/Radio';
 import { Text } from '@/shared/components/common/Text';
 import { Title } from '@/shared/components/common/Title';
+import { useForm } from '@/shared/hooks/useForm';
 
 export const Display3dModel = () => {
+  const [opened, { open, close }] = useDisclosure(false);
+  const mock3dModels: { id: number; imageSrc: string }[] = [
+    {
+      id: 1,
+      imageSrc: '/3d_model_image.svg',
+    },
+    {
+      id: 2,
+      imageSrc: '/3d_model_image.svg',
+    },
+    {
+      id: 3,
+      imageSrc: '/3d_model_image.svg',
+    },
+  ];
+  const { control } = useForm();
+  const sampleModels = mock3dModels;
+  const uploadedModels = mock3dModels;
   return (
     <Stack gap={0}>
       <Title order={5} c="blue.6" mb={4}>
@@ -15,7 +41,71 @@ export const Display3dModel = () => {
       </Text>
       <Group justify="center" mt={8}>
         <Image src="/3d_model_image.svg" alt="3d_model_image" height={160} />
-        <Button variant="outline" color="orange" radius="xl">
+
+        <Modal opened={opened} onClose={close}>
+          <Container>
+            <Title order={5} mb={4} c="dark">
+              サンプル3Dモデル
+            </Title>
+            <Text size="xs" c="gray.6" mb={12}>
+              サンプルから選択してください
+            </Text>
+
+            <Grid gutter="sm">
+              {sampleModels.map(({ id, imageSrc }) => {
+                return (
+                  <Grid.Col key={id} span={4}>
+                    <Stack gap="sm" align="center">
+                      <Image src={imageSrc} alt={`${id} 3d model`} />
+                      {/* TODO: wip */}
+                      <Radio name="" control={control} size="xs" />
+                    </Stack>
+                  </Grid.Col>
+                );
+              })}
+            </Grid>
+            <Divider my="sm" labelPosition="center" />
+
+            <Title order={5} mb={4} c="dark">
+              アップロードした3Dモデル
+            </Title>
+            <Text size="xs" c="gray.6" mb={12}>
+              自分でアップロードした3Dモデルになっております。
+            </Text>
+            <Grid>
+              {uploadedModels.map(({ id, imageSrc }) => {
+                return (
+                  <Grid.Col key={id} span={4}>
+                    <Stack gap="sm" align="center">
+                      <Image src={imageSrc} alt={`${id} 3d model`} />
+                      {/* TODO: wip */}
+                      <Radio name="" control={control} size="xs" />
+                    </Stack>
+                  </Grid.Col>
+                );
+              })}
+              <Grid.Col span={4}>
+                <FileInput
+                  // TODO: wip
+                  name=""
+                  control={control}
+                  placeholder="アップロード"
+                  size="xs"
+                  styles={{
+                    wrapper: { height: '100%' },
+                    root: { height: '100%' },
+                    input: { height: 'calc(100% - 28px)' },
+                  }}
+                />
+              </Grid.Col>
+            </Grid>
+            <Button onClick={close} w="100%" radius="md">
+              選択
+            </Button>
+          </Container>
+        </Modal>
+
+        <Button variant="outline" color="orange" radius="xl" onClick={open}>
           選択する
         </Button>
       </Group>

--- a/src/shared/components/common/Modal/Modal.tsx
+++ b/src/shared/components/common/Modal/Modal.tsx
@@ -1,0 +1,3 @@
+import { Modal as MantineModal } from '@mantine/core';
+
+export const Modal = MantineModal;

--- a/src/shared/components/common/Modal/index.ts
+++ b/src/shared/components/common/Modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal } from './Modal';

--- a/src/shared/hooks/useDisclosure.ts
+++ b/src/shared/hooks/useDisclosure.ts
@@ -1,0 +1,3 @@
+import { useDisclosure as useReactHookDisclosure } from '@mantine/hooks';
+
+export const useDisclosure = useReactHookDisclosure;


### PR DESCRIPTION
### 関連issue

- close #91 

### 説明
選択するボタンをおしたらModalが開くようにしました
<img width="671" alt="スクリーンショット 2023-12-12 15 50 11" src="https://github.com/Misoten-B/airship-frontend/assets/85974240/782124c0-6c33-4f57-b614-4a7dd01e0069">

Modal画面
<img width="445" alt="スクリーンショット 2023-12-12 15 23 50" src="https://github.com/Misoten-B/airship-frontend/assets/85974240/0e9d7d65-43be-4a0b-a772-ad7a0e80baf8">

Modal  componentsの追加
<!-- 関連issueがある場合は省略してください -->

### その他

<!-- 追記事項。そのほかお見送り事項 -->
