### PR TITLE
add:Buttonを押したら適切な場所に移動するようにしました

### DIFF
--- a/src/app/ar-assets/_components/ArAssetCard.tsx
+++ b/src/app/ar-assets/_components/ArAssetCard.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/shared/components/common/Button';
 import { Divider } from '@/shared/components/common/Divider';
 import { Image } from '@/shared/components/common/Image';
 import { Card, Flex } from '@/shared/components/common/Layout';
+import { Anchor } from '@/shared/components/common/Navigation';
 import { QRCode } from '@/shared/components/common/QRCode';
 import { Text } from '@/shared/components/common/Text';
 import { Title } from '@/shared/components/common/Title';
@@ -35,12 +36,14 @@ export const ArAssetCard = ({ text, url }: Props) => {
       </Card.Section>
       <Card.Section>
         <Divider mt="md" />
-        <Button
-          variant="subtle"
-          size="md"
-          fullWidth
-          leftSection={<IconPencil />}
-        />
+        <Anchor href="ar-assets/[ar_asset_id]">
+          <Button
+            variant="subtle"
+            size="md"
+            fullWidth
+            leftSection={<IconPencil />}
+          />
+        </Anchor>
       </Card.Section>
     </Card>
   );

--- a/src/app/ar-assets/_components/ArAssetList.tsx
+++ b/src/app/ar-assets/_components/ArAssetList.tsx
@@ -8,6 +8,7 @@ import {
   SimpleGrid,
   Stack,
 } from '@/shared/components/common/Layout';
+import { Anchor } from '@/shared/components/common/Navigation';
 import { Text } from '@/shared/components/common/Text';
 
 const arAssets = [
@@ -32,15 +33,17 @@ export const ArAssetList = () => {
             <Text size="xs" c="orange" ta="center" mb={4}>
               3Dモデルと話させる文章を登録して QRコード化させます
             </Text>
-            <Button
-              variant="filled"
-              color="orange"
-              size="md"
-              radius="xl"
-              w="100%"
-            >
-              <Text>QRコードの新規作成</Text>
-            </Button>
+            <Anchor href="/ar-assets/create">
+              <Button
+                variant="filled"
+                color="orange"
+                size="md"
+                radius="xl"
+                w="100%"
+              >
+                <Text>QRコードの新規作成</Text>
+              </Button>
+            </Anchor>
           </Stack>
           <Stack gap={0}>
             <Text size="xs" c="blue" ta="center" mb={4}>

--- a/src/app/ar-assets/create/_components/CreateArAssetStepper.tsx
+++ b/src/app/ar-assets/create/_components/CreateArAssetStepper.tsx
@@ -75,7 +75,7 @@ export const CreateArAssetStepper = () => {
       </Stepper>
 
       {active == 3 ? (
-        <Anchor component={Link} href="/ar_assets">
+        <Anchor component={Link} href="/ar-assets">
           QRコード一覧へ
         </Anchor>
       ) : (


### PR DESCRIPTION
### 関連issue

- close #00

### 説明

QRコードの新規作成ボタンを押したら「QR作成-step1 3Dモデルのアップロード/選択」の画面に飛ぶようにしました
カードの編集ボタンも押したら「QR詳細」画面に飛ぶようにしました。
<img width="1007" alt="スクリーンショット 2023-12-14 14 57 11" src="https://github.com/Misoten-B/airship-frontend/assets/85974240/bed405cd-392f-4eb9-9d50-5248eda776dc">


<!-- 関連issueがある場合は省略してください -->

### その他

<!-- 追記事項。そのほかお見送り事項 -->
